### PR TITLE
[GH-54] Add admin and user clients

### DIFF
--- a/server/api/user_test.go
+++ b/server/api/user_test.go
@@ -8,47 +8,94 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestUserLogin(t *testing.T) {
+	th := functionaltesting.Setup(t)
+	defer th.TearDown()
+
+	t.Run("can't login with non-existent user", func(t *testing.T) {
+		_, resp, err := th.Client.LoginByEmail("bla", "bla")
+		require.Error(t, err)
+		functionaltesting.CheckUnauthorizedStatus(t, resp)
+	})
+
+	t.Run("can't register user without username", func(t *testing.T) {
+		user := model.User{
+			Email:    "bla@gmail.com",
+			Password: "hello1",
+		}
+		_, resp, err := th.Client.RegisterUser(&user)
+		require.Error(t, err)
+		functionaltesting.CheckConflictStatus(t, resp) //TODO fix error codes returned by server
+	})
+
+	t.Run("can register user", func(t *testing.T) {
+		user := model.User{
+			Email:         "bla@gmail.com",
+			Password:      "hello1",
+			EmailVerified: true,
+			Username:      "user",
+		}
+		registeredUser, resp, err := th.Client.RegisterUser(&user)
+		require.NoError(t, err)
+		functionaltesting.CheckCreatedStatus(t, resp)
+		// Creating a user as a regular user with verified flag should not verify the new user.
+		require.False(t, registeredUser.EmailVerified)
+	})
+
+	t.Run("can register user and log in", func(t *testing.T) {
+		user := model.User{
+			Email:         "bla3@gmail.com",
+			Password:      "hello1",
+			EmailVerified: true,
+			Username:      "user3",
+		}
+		registeredUser, resp, err := th.Client.RegisterUser(&user)
+		require.NoError(t, err)
+		functionaltesting.CheckCreatedStatus(t, resp)
+
+		loggedInUser, resp, err := th.Client.LoginByEmail(user.Email, user.Password)
+		require.NoError(t, err)
+		functionaltesting.CheckOKStatus(t, resp)
+		require.Equal(t, loggedInUser.ID, registeredUser.ID)
+	})
+}
+
 func TestCreateUser(t *testing.T) {
 	th := functionaltesting.Setup(t)
 	defer th.TearDown()
 
-	_, resp, err := th.Client.LoginByEmail("bla", "bla")
-	require.NotNil(t, err)
-	functionaltesting.CheckUnauthorizedStatus(t, resp)
+	t.Run("user can't be created without authentication", func(t *testing.T) {
+		user := model.User{
+			Email:         "bla@gmail.com",
+			Password:      "hello1",
+			EmailVerified: true,
+			Username:      "user",
+		}
+		_, resp, err := th.Client.CreateUser(&user)
+		require.Error(t, err)
+		functionaltesting.CheckUnauthorizedStatus(t, resp)
+	})
 
-	user := model.User{
-		Email:         "bla@gmail.com",
-		Password:      "hello1",
-		EmailVerified: true,
-	}
-	_, _, err = th.Client.RegisterUser(&user)
-	require.NotNil(t, err)
+	t.Run("user can't be created by the basic user", func(t *testing.T) {
+		user := model.User{
+			Email:         "bla@gmail.com",
+			Password:      "hello1",
+			EmailVerified: true,
+			Username:      "user",
+		}
+		_, resp, err := th.UserClient.CreateUser(&user)
+		require.Error(t, err)
+		functionaltesting.CheckForbiddenStatus(t, resp)
+	})
 
-	user.Username = "user"
-	registeredUser, resp, err := th.Client.RegisterUser(&user)
-	require.NoError(t, err)
-	functionaltesting.CheckCreatedStatus(t, resp)
-	// Creating a user as a regular user with verified flag should not verify the new user.
-	require.False(t, registeredUser.EmailVerified)
-
-	loggedInUser, resp, err := th.Client.LoginByEmail(user.Email, user.Password)
-	require.NoError(t, err)
-	functionaltesting.CheckOKStatus(t, resp)
-	require.Equal(t, loggedInUser.ID, registeredUser.ID)
-
-	newUser := model.User{
-		Email:    "bla2@gmail.com",
-		Password: "hello1",
-		Username: "bla2",
-	}
-	_, resp, err = th.Client.CreateUser(&newUser)
-	require.NotNil(t, err)
-	functionaltesting.CheckForbiddenStatus(t, resp)
-
-	registeredUser.Role = model.AdminRole
-	err = th.Server.App.UpdateUser(registeredUser)
-	require.Nil(t, err)
-
-	_, _, err = th.Client.CreateUser(&newUser)
-	require.Nil(t, err)
+	t.Run("user can be created by the admin", func(t *testing.T) {
+		user := model.User{
+			Email:         "bla@gmail.com",
+			Password:      "hello1",
+			EmailVerified: true,
+			Username:      "user",
+		}
+		_, _, err := th.AdminClient.CreateUser(&user)
+		require.NoError(t, err)
+	})
 }

--- a/server/functionaltesting/apitestlib.go
+++ b/server/functionaltesting/apitestlib.go
@@ -75,8 +75,8 @@ func (th *TestHelper) Init() {
 	}
 
 	admin.Role = model.AdminRole
-	if err := th.Server.App.UpdateUser(admin); err != nil {
-		panic(err)
+	if err2 := th.Server.App.UpdateUser(admin); err2 != nil {
+		panic(err2)
 	}
 	admin.Password = "Pa$$word11"
 	th.AdminUser = admin


### PR DESCRIPTION
This PR adds admin and user clients to the testing framework.
Now we have 3 clients for testing:

```
1. Client - client with no user logged in
2. AdminClient - client with admin logged in
3. UserClient - client with basic user logged in
```

It'll make things easier


Fixes: #54 