### PR TITLE
[GH-65] import command

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ In the Knowledge Graph each Node consists of name, description, resources(such a
 There is a short video mode of learning similar to youtube shorts, facebook reels or ticktock, where students discover different fields they might be interested in, by watching the videos(honoring the prerequisite graph).
 
 
+## Run Knowledge Graph
+Follow the commands [here](/server/README.md)
+
 ## Interested in contributing?
 Please see [CONTRIBUTING.md](/CONTRIBUTING.md). Also join the [Contributors server](https://knowledge.cloud.mattermost.com) to join discussions about contributions, development, and more.
 

--- a/server/README.md
+++ b/server/README.md
@@ -1,13 +1,18 @@
 # Server for the Knowledge Graph
 
-1. Run server using
+## Import programming methodology content to the DB using
 ```console
-go run cmd/main.go
+go run cmd/main.go db import --url https://raw.githubusercontent.com/oseducation/content-ge/main/programming-methodology/
 ```
 
-Killing the process will stop the server and all the processes on the server.
-
-2. Create admin user using
+## Create admin user using
 ```console
 go run cmd/main.go db create --email bla@gmail.com --password 12345678
 ```
+
+## Run server using
+```console
+go run cmd/main.go
+```
+Killing the process will stop the server and all the processes on the server.
+

--- a/server/app/app.go
+++ b/server/app/app.go
@@ -49,8 +49,8 @@ func (a *App) ImportGraph(url string) error {
 		return errors.Wrap(err, "can't get graph.json file")
 	}
 	var graph map[string][]string
-	if err := json.Unmarshal([]byte(graphContent), &graph); err != nil {
-		return errors.Wrap(err, "can't unmarshal graph.json file")
+	if err2 := json.Unmarshal([]byte(graphContent), &graph); err2 != nil {
+		return errors.Wrap(err2, "can't unmarshal graph.json file")
 	}
 
 	nodesContent, err := getFileContent(fmt.Sprintf("%s/nodes.json", url))

--- a/server/config/config.json
+++ b/server/config/config.json
@@ -1,8 +1,7 @@
 {
     "ServerSettings": {
         "SiteURL": "http://localhost:8065",
-        "ListenAddress": ":8065",
-        "KnowledgeGraphImportURL": "https://raw.githubusercontent.com/oseducation/content-ge/main/content.md"
+        "ListenAddress": ":8065"
     },
     "DBSettings": {
         "DriverName": "sqlite3",

--- a/server/store/graph.go
+++ b/server/store/graph.go
@@ -61,8 +61,8 @@ func (gs *SQLGraphStore) GetEdges(options *model.EdgeGetOptions) ([]*model.Edge,
 	if options.PerPage > 0 {
 		query = query.Limit(uint64(options.PerPage))
 	}
-	if options.Page > 0 {
-		query = query.Offset(uint64(options.Page))
+	if options.Page >= 0 {
+		query = query.Offset(uint64(options.Page * options.PerPage))
 	}
 
 	if err := gs.sqlStore.selectBuilder(gs.sqlStore.db, &edges, query); err != nil {

--- a/server/store/node.go
+++ b/server/store/node.go
@@ -118,8 +118,8 @@ func (ns *SQLNodeStore) GetNodes(options *model.NodeGetOptions) ([]*model.Node, 
 	if options.PerPage > 0 {
 		query = query.Limit(uint64(options.PerPage))
 	}
-	if options.Page > 0 {
-		query = query.Offset(uint64(options.Page))
+	if options.Page >= 0 {
+		query = query.Offset(uint64(options.Page * options.PerPage))
 	}
 
 	if err := ns.sqlStore.selectBuilder(ns.sqlStore.db, &nodes, query); err != nil {

--- a/server/store/user.go
+++ b/server/store/user.go
@@ -145,8 +145,8 @@ func (us *SQLUserStore) GetUsers(options *model.UserGetOptions) ([]*model.User, 
 	if options.PerPage > 0 {
 		query = query.Limit(uint64(options.PerPage))
 	}
-	if options.Page > 0 {
-		query = query.Offset(uint64(options.Page))
+	if options.Page >= 0 {
+		query = query.Offset(uint64(options.Page * options.PerPage))
 	}
 
 	if err := us.sqlStore.selectBuilder(us.sqlStore.db, &users, query); err != nil {


### PR DESCRIPTION
This PR adds import command, so you can import the content to the DB directly.
Use command:
```console
go run cmd/main.go db import --url https://raw.githubusercontent.com/oseducation/content-ge/main/programming-methodology
```

Fixes: #65 