### PR TITLE
[GH-81] Add user auth

### DIFF
--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -6,6 +6,8 @@ import LoginPage from './pages/LoginPage';
 import RegisterPage from './pages/RegisterPage';
 import WelcomePage from './pages/WelcomePage';
 import HomePage from './pages/HomePage';
+import RequireAuth from './components/require_auth';
+import {ROLES} from './types/users';
 
 
 function App() {
@@ -14,7 +16,9 @@ function App() {
             <Route path="/" element={<HomePage/>}/>
             <Route path="/login" element={<LoginPage/>}/>
             <Route path="/register" element={<RegisterPage/>}/>
-            <Route path="/welcome" element={<WelcomePage/>}/>
+            <Route element={<RequireAuth allowedRoles={[ROLES.User]}/>}>
+                <Route path="/welcome" element={<WelcomePage/>}/>
+            </Route>
         </Routes>
     );
 }

--- a/webapp/src/components/require_auth.tsx
+++ b/webapp/src/components/require_auth.tsx
@@ -1,0 +1,22 @@
+import React from 'react'
+import {useLocation, Navigate, Outlet} from "react-router-dom";
+import useAuth from "../hooks/useAuth";
+
+interface Props {
+    allowedRoles: string[];
+}
+
+const RequireAuth = (props: Props) => {
+    const {user} = useAuth();
+    const location = useLocation();
+
+    if (user?.role && props.allowedRoles?.includes(user?.role)){
+        return <Outlet/>
+    }
+    if (user) {
+        return <Navigate to="/unauthorized" state={{ from: location }} replace/>
+    }
+    return <Navigate to="/login" state={{ from: location }} replace/>
+}
+
+export default RequireAuth;

--- a/webapp/src/components/require_auth.tsx
+++ b/webapp/src/components/require_auth.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import {useLocation, Navigate, Outlet} from "react-router-dom";
+
 import useAuth from "../hooks/useAuth";
 
 interface Props {

--- a/webapp/src/context/auth_provider.tsx
+++ b/webapp/src/context/auth_provider.tsx
@@ -1,0 +1,31 @@
+import React, {createContext, useState, PropsWithChildren}  from 'react';
+import {User} from '../types/users';
+
+
+interface UserContextState {
+    user: User | null;
+    setUser: React.Dispatch<React.SetStateAction<User | null>> | null;
+}
+
+const AuthContext = createContext<UserContextState>({
+    user: null,
+    setUser: null
+});
+
+interface Props{
+    children: React.ReactNode
+}
+
+export const AuthProvider = (props: Props) => {
+    const [user, setUser] = useState<User | null>(null);
+
+    return (
+        <AuthContext.Provider value={{user, setUser}}>
+            {props.children}
+        </AuthContext.Provider>
+    );
+}
+
+export default AuthContext;
+
+

--- a/webapp/src/context/auth_provider.tsx
+++ b/webapp/src/context/auth_provider.tsx
@@ -1,4 +1,5 @@
-import React, {createContext, useState, PropsWithChildren}  from 'react';
+import React, {createContext, useState}  from 'react';
+
 import {User} from '../types/users';
 
 

--- a/webapp/src/hooks/useAuth.tsx
+++ b/webapp/src/hooks/useAuth.tsx
@@ -1,0 +1,8 @@
+import {useContext} from 'react';
+import AuthContext from '../context/auth_provider';
+
+const useAuth = () => {
+    return useContext(AuthContext);
+}
+
+export default useAuth;

--- a/webapp/src/hooks/useAuth.tsx
+++ b/webapp/src/hooks/useAuth.tsx
@@ -1,4 +1,5 @@
 import {useContext} from 'react';
+
 import AuthContext from '../context/auth_provider';
 
 const useAuth = () => {

--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -4,11 +4,14 @@ import {BrowserRouter} from 'react-router-dom';
 
 import './index.css';
 import App from './App';
+import {AuthProvider} from './context/auth_provider';
 
 ReactDOM.render((
     <React.StrictMode>
-        <BrowserRouter>
-            <App/>
-        </BrowserRouter>
+        <AuthProvider>
+            <BrowserRouter>
+                <App/>
+            </BrowserRouter>
+        </AuthProvider>
     </React.StrictMode>
 ), document.getElementById('root'));

--- a/webapp/src/pages/LoginPage.tsx
+++ b/webapp/src/pages/LoginPage.tsx
@@ -1,15 +1,19 @@
 import React from 'react';
 import {Alert, Button, Stack, TextField, Typography} from '@mui/material';
-import {useNavigate} from 'react-router-dom';
+import {useLocation, useNavigate} from 'react-router-dom';
 import styled from 'styled-components';
 import {useForm} from "react-hook-form";
 
 import {Client} from '../client/client';
 import {ClientError} from "../client/rest";
+import useAuth from '../hooks/useAuth';
 
 const LoginPage = () => {
-
     const navigate = useNavigate();
+    const location = useLocation();
+    const from = location.state?.from?.pathname || "/welcome";
+    const {setUser} = useAuth();
+
 
     type FormData = {
         email: string,
@@ -21,7 +25,10 @@ const LoginPage = () => {
 
     const onSubmit = (data: FormData) => {
         Client.User().login(data.email, data.password)
-            .then(() => navigate('/welcome')).catch((err: ClientError) => {
+            .then((user) => {
+                setUser?.(user);
+                return navigate(from, {replace: true});
+            }).catch((err: ClientError) => {
                 setError('root', {type: 'server', message: err.message});
             })
     }

--- a/webapp/src/pages/WelcomePage.tsx
+++ b/webapp/src/pages/WelcomePage.tsx
@@ -3,10 +3,12 @@ import {Button, Stack} from '@mui/material';
 import {useNavigate} from 'react-router-dom';
 
 import {Client} from '../client/client';
+import useAuth from '../hooks/useAuth';
 
 const WelcomePage = () => {
 
     const navigate = useNavigate();
+    const {user} = useAuth()
 
     const logOutHandler = () => {
         Client.User().logout().then(() => {
@@ -17,6 +19,7 @@ const WelcomePage = () => {
     return (
         <Stack direction={'column'} justifyContent={'center'} alignItems={'center'}>
             <h1>Welcome Page!</h1>
+            <h2>{'Hello  ' + user?.first_name}</h2>
             <Button onClick={logOutHandler}>Log Out</Button>
         </Stack>
     )

--- a/webapp/src/types/users.ts
+++ b/webapp/src/types/users.ts
@@ -8,7 +8,12 @@ export type User = {
     email: string;
     first_name: string;
     last_name: string;
-    roles: string;
+    role: string;
     last_password_update: number;
     props: Record<string, string>;
+};
+
+export const ROLES = {
+    'Admin': 'admin',
+    'User': 'user'
 };


### PR DESCRIPTION
This PR adds user auth.
Users who are not logged in can not access `welcome` page.
Now we have logged in `user` object in the context and welcome page shows user's name

Fixes: #81 