### PR TITLE
[GH-109] Add example type

### DIFF
--- a/server/api/auth_middleware.go
+++ b/server/api/auth_middleware.go
@@ -79,7 +79,7 @@ func parseAuthTokenFromRequest(r *http.Request) string {
 	// Parse the token from the header
 	if len(authHeader) > len(HeaderBearer) && strings.EqualFold(authHeader[0:len(HeaderBearer)], HeaderBearer) {
 		// Default session token
-		return authHeader[7:]
+		return authHeader[len(HeaderBearer)+1:]
 	}
 	return ""
 }

--- a/server/api/graph.go
+++ b/server/api/graph.go
@@ -27,6 +27,7 @@ func getGraph(c *gin.Context) {
 			ID:          node.ID,
 			Name:        node.Name,
 			Description: node.Description,
+			NodeType:    node.NodeType,
 		})
 	}
 	gr.Links = []model.FrontendLinks{}

--- a/server/app/app.go
+++ b/server/app/app.go
@@ -58,11 +58,30 @@ func (a *App) ImportGraph(url string) error {
 		return errors.Wrap(err, "can't get nodes.json file")
 	}
 	var nodes map[string]model.Node
-	if err := json.Unmarshal([]byte(nodesContent), &nodes); err != nil {
+	if err2 := json.Unmarshal([]byte(nodesContent), &nodes); err2 != nil {
 		return errors.Wrap(err, "can't unmarshal nodes.json file")
 	}
 
+	examplesContent, err := getFileContent(fmt.Sprintf("%s/examples.json", url))
+	if err != nil {
+		return errors.Wrap(err, "can't get examples.json file")
+	}
+	var exampleNodes map[string]model.Node
+	if err := json.Unmarshal([]byte(examplesContent), &exampleNodes); err != nil {
+		return errors.Wrap(err, "can't unmarshal examples.json file")
+	}
+
 	for id, node := range nodes {
+		node.NodeType = model.NodeTypeLecture
+		updatedNode, err := a.Store.Node().Save(&node)
+		if err != nil {
+			return errors.Wrap(err, "can't save node")
+		}
+		nodes[id] = *updatedNode
+	}
+
+	for id, node := range exampleNodes {
+		node.NodeType = model.NodeTypeExample
 		updatedNode, err := a.Store.Node().Save(&node)
 		if err != nil {
 			return errors.Wrap(err, "can't save node")

--- a/server/model/graph.go
+++ b/server/model/graph.go
@@ -19,6 +19,7 @@ type FrontendNodes struct {
 	ID          string `json:"id"`
 	Name        string `json:"name"`
 	Description string `json:"description"`
+	NodeType    string `json:"node_type"`
 }
 
 type FrontendLinks struct {

--- a/server/model/node.go
+++ b/server/model/node.go
@@ -12,6 +12,8 @@ const (
 	NodeNameMaxRunes        = 128
 	NodeNameMinRunes        = 3
 	NodeDescriptionMaxRunes = 2048
+	NodeTypeLecture         = "lecture"
+	NodeTypeExample         = "example"
 )
 
 // Node type defines Knowledge Graph node
@@ -22,6 +24,7 @@ type Node struct {
 	DeletedAt   int64  `json:"deleted_at" db:"deleted_at"`
 	Name        string `json:"name" db:"name"`
 	Description string `json:"description,omitempty" db:"description"`
+	NodeType    string `json:"node_type" db:"node_type"`
 }
 
 type NodeWithResources struct {
@@ -49,6 +52,10 @@ func (n *Node) IsValid() error {
 
 	if utf8.RuneCountInString(n.Description) > NodeDescriptionMaxRunes {
 		return invalidNodeError(n.ID, "description", n.Description)
+	}
+
+	if n.NodeType != NodeTypeExample && n.NodeType != NodeTypeLecture {
+		return invalidNodeError(n.ID, "node_type", n.NodeType)
 	}
 
 	return nil

--- a/server/store/migrations.go
+++ b/server/store/migrations.go
@@ -63,7 +63,8 @@ var migrations = []Migration{
 					updated_at bigint,
 					deleted_at bigint,
 					name VARCHAR(128) UNIQUE,
-					description VARCHAR(2048)
+					description VARCHAR(2048),
+					node_type VARCHAR(32)
 				);
 			`); err != nil {
 				return errors.Wrapf(err, "failed creating table nodes")

--- a/server/store/node.go
+++ b/server/store/node.go
@@ -33,6 +33,7 @@ func NewNodeStore(db *SQLStore) NodeStore {
 			"n.deleted_at",
 			"n.name",
 			"n.description",
+			"n.node_type",
 		).
 		From("nodes n")
 
@@ -61,6 +62,7 @@ func (ns *SQLNodeStore) Save(node *model.Node) (*model.Node, error) {
 			"deleted_at":  node.DeletedAt,
 			"name":        node.Name,
 			"description": node.Description,
+			"node_type":   node.NodeType,
 		}))
 	if err != nil {
 		return nil, errors.Wrapf(err, "can't save node with name:%s", node.Name)
@@ -84,6 +86,7 @@ func (ns *SQLNodeStore) Update(new *model.Node) error {
 			"deleted_at":  new.DeletedAt,
 			"name":        new.Name,
 			"description": new.Description,
+			"node_type":   new.NodeType,
 		}).
 		Where(sq.Eq{"ID": new.ID}))
 	if err != nil {

--- a/webapp/src/components/3d_force_graph.tsx
+++ b/webapp/src/components/3d_force_graph.tsx
@@ -32,6 +32,7 @@ const D3ForceGraph = (props: Props) => {
                 linkDirectionalParticleWidth={2}
                 linkWidth={2}
                 onNodeClick={onNodeClick}
+                nodeAutoColorBy={"node_type"}
             />
         );
     }
@@ -71,6 +72,7 @@ const D3ForceGraph = (props: Props) => {
                     ctx.fillRect(node.x||0 - bckgDimensions[0] / 2, node.y||0 - bckgDimensions[1] / 2, bckgDimensions[0], bckgDimensions[1]);
                 }
             }}
+            nodeAutoColorBy={"node_type"}
         />
     )
 

--- a/webapp/src/components/graph.tsx
+++ b/webapp/src/components/graph.tsx
@@ -29,19 +29,19 @@ const GraphComponent = () => {
         <Container>
             <Stack width={1000} height={1800}  display={'flex'} alignItems={'center'}>
                 <ForceGraph
-                    graph={graph}
+                    graph={{...graph}}
                     width={1000}
                     height={600}
                     d3={false}
                 />
                 <ForceGraph
-                    graph={graph}
+                    graph={{...graph}}
                     width={1000}
                     height={600}
                     d3={true}
                 />
                 <ReactD3Graph
-                    graph={graph}
+                    graph={{...graph}}
                     width={1000}
                     height={600}
                 />

--- a/webapp/src/components/react_d3_graph.tsx
+++ b/webapp/src/components/react_d3_graph.tsx
@@ -39,6 +39,11 @@ const ReactD3Graph = (props: Props) => {
         height: props.height,
     };
 
+    const newNodes = props.graph.nodes.map(node => {
+        return {...node, symbolType: node.node_type === 'lecture' ? 'circle' : 'square', color: node.node_type === 'lecture' ? 'green' : 'blue'}
+    });
+    props.graph.nodes = newNodes;
+
     return (
         <ReactD3GraphComponent
             id="graph-id"

--- a/webapp/src/types/graph.ts
+++ b/webapp/src/types/graph.ts
@@ -2,6 +2,7 @@ export type Node = {
     id: string;
     name: string;
     description: string;
+    node_type: string;
 }
 
 export type Link = {


### PR DESCRIPTION
This PR adds example type to the node, coloured with different colour. See the view of the graph:

<img width="712" alt="Screenshot 2023-05-13 at 12 57 45" src="https://github.com/oseducation/knowledge-graph/assets/2340127/835454a2-3cd6-4777-89d6-d4d6c04feb75">

Fixes: #109 

