### PR TITLE
[GH-112] Add nuke db

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,4 +29,10 @@ docker-start:
 docker-stop:
 	docker-compose down
 
+import:
+	cd server && go run cmd/main.go db import --url https://raw.githubusercontent.com/oseducation/content-ge/main/programming-methodology/
 
+nuke:
+	cd server && go run cmd/main.go db nuke
+
+n-run: nuke import run

--- a/server/cmd/commands/db.go
+++ b/server/cmd/commands/db.go
@@ -30,6 +30,14 @@ var dbImportGraph = &cobra.Command{
 	RunE:    importGraphCmdF,
 }
 
+var dbNuke = &cobra.Command{
+	Use:     "nuke",
+	Short:   "Nuke DB",
+	Long:    `Remove all data from the DB`,
+	Example: `  db nuke `,
+	RunE:    nukeDB,
+}
+
 func init() {
 	dbCreateAdmin.Flags().String("email", "", "Admin email")
 	dbCreateAdmin.Flags().String("password", "", "Admin password")
@@ -37,6 +45,8 @@ func init() {
 
 	dbImportGraph.Flags().String("url", "", "URL to folder with graph.json file")
 	dbCmd.AddCommand(dbImportGraph)
+
+	dbCmd.AddCommand(dbNuke)
 
 	rootCmd.AddCommand(dbCmd)
 }
@@ -67,6 +77,19 @@ func createAdminCmdF(command *cobra.Command, _ []string) error {
 	if err != nil {
 		return errors.Wrap(err, "can't save admin in DB")
 	}
+	return nil
+}
+
+func nukeDB(command *cobra.Command, _ []string) error {
+	conf, err := config.ReadConfig()
+	if err != nil {
+		return errors.Wrap(err, "can't read config")
+	}
+	db := store.CreateStore(&conf.DBSettings, log.NewLogger(&log.LoggerConfiguration{NonLogger: true}))
+	if err := db.Nuke(); err != nil {
+		return errors.Wrap(err, "can't nuke DB")
+	}
+
 	return nil
 }
 

--- a/server/cmd/commands/db.go
+++ b/server/cmd/commands/db.go
@@ -80,7 +80,7 @@ func createAdminCmdF(command *cobra.Command, _ []string) error {
 	return nil
 }
 
-func nukeDB(command *cobra.Command, _ []string) error {
+func nukeDB(_ *cobra.Command, _ []string) error {
 	conf, err := config.ReadConfig()
 	if err != nil {
 		return errors.Wrap(err, "can't read config")


### PR DESCRIPTION
This PR adds nuke db command to be easier usage in dev mode. Now you can use `make n-run` to run the project after changing the db scheme.

Fixes: #112 