### PR TITLE
[GH-158] optimize server docker file with two stage build

### DIFF
--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -1,21 +1,43 @@
-# Use an official Golang runtime as a parent image
-FROM golang:latest
+# Stage 1: Build Stage
+FROM golang:latest AS build
 
 # Set the working directory
 WORKDIR /knowledge-graph-server
 
 # Copy the Golang server's source code into the container
 COPY ./server .
-RUN chmod +x ./entrypoint.sh
 
 # Install any needed packages specified in go.mod and go.sum
 RUN go mod download
 
+# Build the Go application
+RUN cd cmd && go build -o kg-server
+
+# Stage 2: Runtime Stage
+FROM ubuntu:22.04
+
+# Set the working directory
+WORKDIR /knowledge-graph-server
+
+# Copy the binary from the build stage
+COPY --from=build /knowledge-graph-server/cmd/kg-server .
+RUN chmod +x ./kg-server
+
+# Copy the entrypoint script
+COPY ./server/entrypoint.sh .
+RUN chmod +x ./entrypoint.sh
+
+# Copy the config file
+COPY ./server/config/config.json ./config/config.json
+
+# Install jq for json config file processing
+RUN apt-get update \
+    && apt-get install -y jq ca-certificates \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
 # Make port 9081 available to the world outside this container
 EXPOSE 9081
-
-# Install jq for json congig file processing
-RUN apt update && apt install -y jq
 
 # Run the server when the container launches
 ENTRYPOINT ["/knowledge-graph-server/entrypoint.sh"]

--- a/Makefile
+++ b/Makefile
@@ -23,17 +23,26 @@ style: golangci-lint vet eslint ## Runs style/lint checks
 test:
 	cd server && go test ./...
 
+docker-build:
+	docker compose build --no-cache
+
 docker-start:
 	docker compose up -d
+
+docker-start-fg:
+	docker compose up
 
 docker-stop:
 	docker compose down
 
-docker-import:
-	docker exec kg-server go run cmd/main.go db import --url https://raw.githubusercontent.com/oseducation/content-ge/main/programming-methodology/
+docker-import: docker-start
+	docker exec kg-server /knowledge-graph-server/kg-server db import --url https://raw.githubusercontent.com/oseducation/content-ge/main/programming-methodology/
+
+docker-container-rm: docker-stop
+	docker compose rm
 
 docker-nuke:
-	docker exec kg-server go run cmd/main.go db nuke
+	docker exec kg-server /knowledge-graph-server/kg-server db nuke
 
 import:
 	cd server && go run cmd/main.go db import --url https://raw.githubusercontent.com/oseducation/content-ge/main/programming-methodology/

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,6 +10,8 @@ services:
       - POSTGRES_PASSWORD=mysecretpassword
       - POSTGRES_USER=postgres
       - POSTGRES_DB=postgres
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
     networks:
       - kg-network
 
@@ -45,3 +47,6 @@ services:
 networks:
   kg-network:
     driver: bridge
+
+volumes:
+  postgres-data:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -28,6 +28,8 @@ services:
     environment:
       - DATABASE_DRIVER_NAME=postgres
       - DATABASE_DATASOURCE=host=kg-db port=5432 user=postgres password=mysecretpassword dbname=postgres sslmode=disable
+    depends_on:
+      - kg-db
 
   kg-webapp:
     build:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -18,6 +18,7 @@ services:
       context: .
       dockerfile: Dockerfile.server
     container_name: kg-server
+    restart: always
     ports:
       - '9081:9081'
     networks:
@@ -31,6 +32,7 @@ services:
       context: .
       dockerfile: Dockerfile.webapp
     container_name: kg-webapp
+    restart: always
     ports:
       - '9091:9091'
     environment:

--- a/server/entrypoint.sh
+++ b/server/entrypoint.sh
@@ -13,4 +13,4 @@ if [ -n "$DATABASE_DATASOURCE" ]; then
 fi
 
 # Run make command
-make run-server
+/knowledge-graph-server/kg-server


### PR DESCRIPTION
This PR optimizes server docker image with two stage build. Previous process built image of 963MB in size, the two stage build creates an image 125MB in size.

The PR also adds utility targets in Makefile.

Fixes #158 